### PR TITLE
fix: Rename metadata column to signal_metadata to resolve SQLAlchemy …

### DIFF
--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -132,7 +132,7 @@ class TradingSignalResponse(BaseModel):
     pattern_id: Optional[int]
     price: float
     confidence: float
-    metadata: Optional[Dict[str, Any]] = None
+    signal_metadata: Optional[Dict[str, Any]] = None
     created_at: datetime
     
     class Config:

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -54,7 +54,7 @@ class TradingSignal(Base):
     pattern_id = Column(Integer, ForeignKey('chart_patterns.id'))
     price = Column(Numeric(20, 10), nullable=False)
     confidence = Column(Numeric(5, 2), nullable=False)
-    metadata = Column(JSONB)
+    signal_metadata = Column(JSONB)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
 
 

--- a/backend/init_db.sql
+++ b/backend/init_db.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS trading_signals (
     pattern_id INTEGER REFERENCES chart_patterns(id),
     price DECIMAL(20, 10) NOT NULL,
     confidence DECIMAL(5, 2) NOT NULL,
-    metadata JSONB,
+    signal_metadata JSONB,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/backend/live_detection/live_detector.py
+++ b/backend/live_detection/live_detector.py
@@ -227,7 +227,7 @@ class LivePatternDetector:
         try:
             query = """
             INSERT INTO trading_signals 
-            (symbol, timeframe, signal_time, signal_type, price, confidence, metadata)
+            (symbol, timeframe, signal_time, signal_type, price, confidence, signal_metadata)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             """
             

--- a/backend/scripts/migrate_to_existing_db.py
+++ b/backend/scripts/migrate_to_existing_db.py
@@ -78,7 +78,7 @@ class DatabaseMigrator:
                     pattern_id INTEGER REFERENCES chart_patterns(id),
                     price DECIMAL(20, 10) NOT NULL,
                     confidence DECIMAL(5, 2) NOT NULL,
-                    metadata JSONB,
+                    signal_metadata JSONB,
                     created_at TIMESTAMPTZ DEFAULT NOW()
                 );
             """,

--- a/backend/signals/signal_generator.py
+++ b/backend/signals/signal_generator.py
@@ -252,7 +252,7 @@ class SignalGenerator:
         
         query = """
         INSERT INTO trading_signals 
-        (symbol, timeframe, signal_time, signal_type, pattern_id, price, confidence, metadata)
+        (symbol, timeframe, signal_time, signal_type, pattern_id, price, confidence, signal_metadata)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         ON CONFLICT DO NOTHING
         """


### PR DESCRIPTION
…reserved keyword

The 'metadata' attribute is reserved in SQLAlchemy's Declarative API. Renamed it to 'signal_metadata' in:
- TradingSignal model
- TradingSignalResponse schema
- Database initialization scripts
- Insert queries in live_detector.py and signal_generator.py

🤖 Generated with [Claude Code](https://claude.ai/code)