### PR TITLE
Fix timestamp handling errors in backend API

### DIFF
--- a/backend/api/datafeed.py
+++ b/backend/api/datafeed.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta
+from dateutil.parser import parse
 import asyncpg
 from config.settings import settings
 from api.schemas import OHLCVBar, SymbolInfo, Configuration
@@ -121,7 +122,7 @@ async def get_history(
             # Format for TradingView
             response = {
                 "s": "ok",
-                "t": [int(bar['time'].timestamp()) for bar in bars],
+                "t": [int(parse(bar['time']).timestamp()) if isinstance(bar['time'], str) else int(bar['time'].timestamp()) for bar in bars],
                 "o": [bar['open'] for bar in bars],
                 "h": [bar['high'] for bar in bars],
                 "l": [bar['low'] for bar in bars],

--- a/backend/api/replay.py
+++ b/backend/api/replay.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Optional
 from datetime import datetime, timedelta
+from dateutil.parser import parse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
 from database.connection import get_async_session
@@ -235,8 +236,14 @@ async def get_replay_bars(
             # Convert to OHLCVBar format
             ohlcv_bars = []
             for bar in bars:
+                # Handle time field - it comes as ISO string from aggregator
+                if isinstance(bar['time'], str):
+                    bar_time = parse(bar['time'])
+                else:
+                    bar_time = bar['time']
+                
                 ohlcv_bars.append(OHLCVBar(
-                    time=int(bar['time'].timestamp() * 1000),  # Milliseconds
+                    time=int(bar_time.timestamp() * 1000),  # Milliseconds
                     open=bar['open'],
                     high=bar['high'],
                     low=bar['low'],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ pydantic-settings==2.1.0
 aiofiles==23.2.1
 python-multipart==0.0.6
 redis==5.0.1
+python-dateutil==2.8.2


### PR DESCRIPTION
- Add python-dateutil import to handle ISO string timestamps
- Fix replay.py: Handle string timestamps from aggregator properly
- Fix datafeed.py: Parse ISO timestamp strings before calling .timestamp()
- Add python-dateutil==2.8.2 to requirements.txt

Resolves "'str' object has no attribute 'timestamp'" errors in replay.py and other backend files.

🤖 Generated with [Claude Code](https://claude.ai/code)